### PR TITLE
Update complete service list: add Errata, reorganize Mirror Service

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,76 +41,12 @@
 # +------------------------------------------------------+ #
 ############################################################
 
-# What is your status page called?
-# Shows up in the browser bar and meta tags
 title: AlmaLinux Status
-
-# Should posts, which have a publish date
-# from the future, be built? Useful for
-# sharing upcoming maintenance, etc.
-#
-# We recommend to keep this at `true`.
-# BOOLEAN; `true`, `false`
 buildFuture: true
-
-# What language do you want to use for the
-# html[lang] definition?
-#
-# Does not change language of site
-# itself.
-#
-# Default: `en`
-# ISO 639-1 defines abbreviations.
-#
-# See:  https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-# Also: https://www.w3schools.com/tags/ref_language_codes.asp
 languageCode: en
-
-# What translation file should cState use?
-# You can also define whether missing
-# translations should get placeholders.
-#
-# For defaultContentLanguage—
-# Default: `en`
-#
-# For enableMissingTranslationPlaceholders—
-# do not set it to true for languages other
-# than English! When tested with Lithuanian,
-# it would add unnecesary placeholders to
-# values that were intentionally empty.
 defaultContentLanguage: en
-
-# What is the hostname or path to the root?
-# Where is the site hosted?
-#
-# ❗ cState & Hugo don’t support '/' in
-# production use. It will break RSS
-# feeds and breaks permalinks since
-# version 3. If you are just testing,
-# localhost should automatically work.
-#
-# Example: 
-# baseUrl: https://status.example.com/
-#
-# For testing:
-# baseUrl: http://localhost
-#
-# Broken example:
-# baseUrl: /
 baseURL: https://status.almalinux.org
-
-# For features like Last modified, you
-# need to use a Git repository. If you
-# are using Netlify, you are already
-# using Git (with GitHub, GitLab, etc)
-#
-# So, should Git information be used
-# for this website?
-#
-# We recommend to keep this at `true`.
-# BOOLEAN; `true`, `false`
 enableGitInfo: true
-
 
 ############################################################
 # +------------------------------------------------------+ #
@@ -119,40 +55,10 @@ enableGitInfo: true
 ############################################################
 
 params:
-  # Before setting up your systems, you need
-  # to first define at least one category.
-  #
-  # Categories are shown in the order that
-  # you define in this config file.
-  #
-  # Categories can have a:
-  # - name
-  # - description
-  # - closed boolean `closed: true`
-  #   That would collapse the category upon first load
-  #   and the user can expand by clicking on the category
-  #   (Requires JavaScript.)
-  # - untitled boolean `untitled: true`
-  #   This would complerely hide the name of the category.
-  #   This is useful, if you do not want to use categories
-  #   because you need to set an 'Uncategorized' category.
-  #   Or it can be used alongside other categories.
-  #
-  # These are case sensitive.
-  # 
-  # For help, see the wiki:
-  # https://github.com/cstate/cstate/wiki/Customization
   categories:
     - name: AlmaLinux Services
       closed: false
 
-  # These are your systems. Change them to
-  # change the amount of components.
-  #
-  # These are case sensitive.
-  #
-  # For help, see the wiki:
-  # https://github.com/cstate/cstate/wiki/Customization
   systems:
     - name: Accounts (accounts.almalinux.org)
       category: AlmaLinux Services
@@ -170,7 +76,11 @@ params:
       category: AlmaLinux Services
     - name: Mattermost (chat.almalinux.org)
       category: AlmaLinux Services
-    - name: Mirror Service
+    - name: Errata (errata.almalinux.org)
+      category: AlmaLinux Services
+    - name: Mirror Service - Primary Mirrors
+      category: AlmaLinux Services
+    - name: Mirror Service - Secondary Mirrors
       category: AlmaLinux Services
     - name: Website (www.almalinux.org)
       category: AlmaLinux Services
@@ -183,220 +93,31 @@ params:
     - name: OpenProject (openproject.almalinux.org)
       category: AlmaLinux Services
 
-
-  # What date format to use?
-  #
-  # Hugo formatting docs:
-  # https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference
-  #
-  # Technical: GOLANG/HUGO .Date.Format & dateFormat
-  #
-  # dateFormat Default: "January 2, 2006 at 3:04 PM"
-  # shortDateFormat Default: "15:04 — Jan 2"
   dateFormat: January 2, 2006 at 3:04 PM UTC
   shortDateFormat: 15:04 UTC — Jan 2
-
-  # Should relative time (x min ago) be used?
-  #
-  # IMPORTANT: In the frontmatter, the dates MUST be in
-  # the UTC time zone for this to work preperly. If you 
-  # use Netlify CMS, all good — the CMS picks UTC time
-  # by default. Otherwise, there may be very inaccurate
-  # times if multiple time zones are in your issue files.
-  #
-  # FOR YOUR CONSIDERATION: This feature was introduced in
-  # v5. It may be a breaking change in the case when you
-  # wish to use relative time but old issues do not have
-  # UTC time (and therefore are out of sync by ±24 hours)
-  #
-  # Read the wiki for more: 
-  # https://github.com/cstate/cstate/wiki/Customization#time 
-  #
-  # If enabled, will display relative times in places like
-  # the incident history and summaries instead of using
-  # dateFormat and shortDateFormat (except for if you use
-  # the old shortcode).
-  #
-  # Default: `true`
-  # BOOLEAN; `true`, `false`
   useRelativeTime: true
- 
-  # If enabled, doesn't show seconds on relative times.
-  #
-  # With option ON (true):
-  # "Last checked <1 min ago"
-  #
-  # With option OFF (false; default):
-  # "Last checked 20s ago"
-  #
-  # Default: `false`
-  # BOOLEAN; `true`, `false`
   skipSeconds: false
-
-  # Should there be an automatic "Last updated"
-  # text shown below issues?
-  #
-  # Default: `true`
-  # BOOLEAN; `true`, `false`
   enableLastMod: true
-
-  # What header design should we use?
-  #
-  # Default: `true`
-  # BOOLEAN; `true`, `false`
   useLargeHeaderDesign: false
-
-  # Should incident history be separated
-  # like in an archive view?
-  #
-  # Note: This WILL disable pagination.
-  #
-  # Default: `yearly`
-  # STRING; `monthly`, `yearly`, `none`
   incidentHistoryFormat: "yearly"
-
   enableCustomHTML: true
-
-  # Should incident history be hidden?
-  #
-  # By disabling the incident history, you also disable
-  # the RSS feed. To ensure no incidents are shown, you
-  # should delete them after they are resolved. This option
-  # overrides any other options that tailor your incident
-  # history’s look.
-  #
-  # Default: `false`
-  # BOOLEAN; `true`, `false`
   disableIncidentHistory: false
-
-  # Disable dark mode
-  #
-  # If your OS and browser support the
-  # `prefers-color-scheme` media query,
-  # cState will automatically switch to
-  # a darker user interface.
-  #
-  # cState uses its built-in colors for
-  # most of the interface to ensure
-  # a good user experience.
-  #
-  # Default: `false`
-  # BOOLEAN; `true`, `false`
   disableDarkMode: false
-
-  # Should we show the logo or the title
-  # of the status page?
-  #
-  # Default: `false`
-  # BOOLEAN; `true`, `false`
   useLogo: true
-
-  # Where is the logo located, if one is
-  # present at all?
-  #
-  # Recommended: png is best used for
-  # images like logos.
-  #
-  # Recommended: png, bmp, jpg, or gif
-  # for best browser support!
   logo: logo.svg
-
-  # This is the description that is shown
-  # on the footer and meta tags.
-  #
-  # Default: We continuously monitor the status of our services and if there are any interruptions, a note will be posted here.
   description: We continuously monitor the status of our services and if there are any interruptions, a note will be posted here.
-
-  # Tabs on homepage
-  # Uncomment to enable.
-  #
-  # Format:
-  # customTabs:
-  #  -
-  #    name: Name
-  #    link: https://example.com
-
-  # Disable complex server-side
-  # calculations that may impact
-  # your build performance
-  #
-  # Disables math calculations
-  # for average downtime on
-  # systems ("/affected/") pages
-  #
-  # Default: `false`
-  # BOOLEAN; `true`, `false`
   disableComplexCalculations: false
-
-  # Incident posts shown
-  # in one page
-  #
-  # NUMERIC; Default: `10`
   incidentPostsPerPage: 10
-
-  # Colors throughout cState
-  #
-  # We recommend using HEX
-  # (with the # symbol).
-  #
-  # Defaults:
-  #
-  # brand: "#0a0c0f"
-  # ok: "#008000"
-  # disrupted: "#cc4400"
-  # down: "#e60000"
-  # notice: "#24478f"
   brand: "#0a0c0f"
   ok: "#44790c"
   disrupted: "#cc4400"
   down: "#e60000"
   notice: "#24478f"
-
-  # If the status page shows that
-  # there are disruptions or outages
-  # happening, should it keep the
-  # brand header color or drop it
-  # and use the status indication
-  # colors that were just defined?
-  #
-  # Default: `true`
-  # BOOLEAN; `true`, `false`
   alwaysKeepBrandColor: true
-
-  # Introduced in v4.0.1 for consistent
-  # site title text color.
-  #
-  # If you do not use the logo, what color
-  # should the site text color be?
-  #
-  # Removing this option will not force
-  # any site text color. This is likely
-  # unwanted behavior.
-  #
-  # Default: `white`
-  # STRING; `white`, `black`, or nothing
   headerTextColor: white
-
-  # Google Analytics tracking code
-  #
-  # By default, cState does not use
-  # Google Analytics. If you choose
-  # to use it, you may change the
-  # placeholder code below to your
-  # own and thereby enable the
-  # tracking service.
-  #
-  # To disable the analytics, change
-  # the value to the default:
-  #
-  # Default: UA-00000000-1
   googleAnalytics: UA-00000000-1
 
-# These options affect the core of cState.
-# Please do not change them if you do not
-# know what you are doing.
 theme: cstate
-
 preserveTaxonomyNames: true
 
 taxonomies:
@@ -425,5 +146,4 @@ outputFormats:
   svg:
     isPlainText: true
     mediaType: image/svg+xml
-
 


### PR DESCRIPTION
This pull request updates the `config.yml` to reflect the current AlmaLinux production environment.

- Added missing service: Errata (errata.almalinux.org)
- Split Mirror Service into:
  - Mirror Service - Primary Mirrors
  - Mirror Service - Secondary Mirrors
- Cleaned up legacy items

Please review and let me know if further adjustments are needed.
(CC @jonathanspw and Infrastructure team for context)

Thank you!
